### PR TITLE
query GET_SHOPPING_LIST for /editlist

### DIFF
--- a/src/components/Editlist/Editlist.js
+++ b/src/components/Editlist/Editlist.js
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { useQuery, useMutation } from "@apollo/react-hooks";
 
 import "./Editlist.css";
-import { GET_USER } from "../../graphql/queries";
+import { GET_SHOPPING_LIST } from "../../graphql/queries";
 import { UPDATE_SHOPPING_LIST } from "../../graphql/mutations";
 import { cloneObj } from "../../utils";
 
@@ -13,30 +13,17 @@ export default function Editlist() {
   const [updateShoppingList, { list, products }] = useMutation(
     UPDATE_SHOPPING_LIST
   );
-  const { loading, error, data } = useQuery(GET_USER);
+  const { loading, error, data } = useQuery(GET_SHOPPING_LIST, {
+    variables: {
+      id: listId,
+    },
+  });
 
-  // const [updateList, { a, p }] = useMutation(`
-
-  // `);
-  console.log("data", data);
-
-  // useEffect(() => {
-  //   if (data) {
-  //     const result = data.shoppingLists.find((list) => {
-  //       return list.id === listId;
-  //     });
-  //     // have to clone, otherwise can't mutate object properties later
-  //     set_productsList({
-  //       title: result.title,
-  //       products: cloneObj(result.products),
-  //     });
-  //   } else {
-  //     set_productsList({
-  //       title: "New List",
-  //       products: [],
-  //     });
-  //   }
-  // }, [data]);
+  useEffect(() => {
+    if (data) {
+      set_productsList(data.shoppingList);
+    }
+  }, [data]);
 
   if (loading) return "Loading...";
   if (error) return error.message;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,25 +1,25 @@
 import gql from "graphql-tag";
 
-export const GET_MESSAGE = gql`
-  query {
-    message
-  }
-`;
-
-export const GET_PRODUCTS = gql`
-  query {
-    products {
-      id
-      name
-    }
-  }
-`;
-
-export const GET_SOPPING_LISTS = gql`
+export const GET_SHOPPING_LISTS = gql`
   query {
     shoppingLists {
       id
       title
+    }
+  }
+`;
+
+export const GET_SHOPPING_LIST = gql`
+  query Ppp($id: Int!) {
+    shoppingList(id: $id) {
+      id
+      title
+      products {
+        id
+        name
+        unit
+        purchased
+      }
     }
   }
 `;


### PR DESCRIPTION
querying single shopping list by id instead querying user with all lists  